### PR TITLE
Fix natural chapter ordering

### DIFF
--- a/gui/sorting.py
+++ b/gui/sorting.py
@@ -1,0 +1,5 @@
+import re
+
+
+def natural_sort_key(value):
+    return [int(part) if part.isdigit() else part.lower() for part in re.split(r'(\d+)', str(value))]

--- a/gui/tabs/downloads_tab.py
+++ b/gui/tabs/downloads_tab.py
@@ -18,6 +18,7 @@ from gui.theme import Colors, Spacing, Fonts
 from gui.components.animated_button import AnimatedButton
 from gui.components.download_card import DownloadCard, DownloadStatus
 from gui.config import get_settings
+from gui.sorting import natural_sort_key
 
 
 class DownloadsTab(QWidget):
@@ -247,7 +248,7 @@ class DownloadsTab(QWidget):
         
         # Sort based on current settings
         if self._sort_by == "name":
-            card_data.sort(key=lambda x: x['name'].lower(), reverse=(self._sort_order == "desc"))
+            card_data.sort(key=lambda x: natural_sort_key(x['name']), reverse=(self._sort_order == "desc"))
         else:  # progress
             card_data.sort(key=lambda x: x['progress'], reverse=(self._sort_order == "desc"))
         

--- a/gui/tabs/library_tab.py
+++ b/gui/tabs/library_tab.py
@@ -19,6 +19,7 @@ from PyQt6.QtGui import QCursor, QPixmap
 from gui.theme import Colors, Spacing, Fonts
 from gui.components.animated_button import AnimatedButton
 from gui.config import get_settings
+from gui.sorting import natural_sort_key
 
 
 class LibraryItem(QFrame):
@@ -603,7 +604,7 @@ class LibraryTab(QWidget):
                 background-color: {Colors.BG_MEDIUM};
             }}
         """)
-        for chapter in sorted(manga_info['chapters']):
+        for chapter in sorted(manga_info['chapters'], key=natural_sort_key):
             chapter_list.addItem(chapter)
         chapters_layout.addWidget(chapter_list)
         

--- a/gui/workers/scraper_worker.py
+++ b/gui/workers/scraper_worker.py
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 from urllib.parse import urljoin
 
 from PyQt6.QtCore import QThread, pyqtSignal
+from gui.sorting import natural_sort_key
 
 logger = logging.getLogger(__name__)
 
@@ -242,7 +243,7 @@ class ScraperWorker(QThread):
         except Exception as e:
             print(f"Error fetching chapters: {e}")
         
-        return chapters
+        return sorted(chapters, key=lambda chapter: natural_sort_key(chapter['name']))
     
     def stop(self):
         """Request the worker to stop."""


### PR DESCRIPTION
## Summary
- sort chapter names naturally across selection, library, and downloads
- share one sort key for consistent ordering

## Verification
- `QT_QPA_PLATFORM=offscreen python3` GUI sorting check
- `python3 -m compileall -q gui`